### PR TITLE
Feat: 로그인 관련 api 연동작업 및 기능 구현

### DIFF
--- a/src/api/PostSignUp.ts
+++ b/src/api/PostSignUp.ts
@@ -1,0 +1,21 @@
+import api from '@/_lib/fetcher';
+
+interface IPostSignUp {
+  email: string;
+  profileImage: string | null;
+  nickname: string;
+  agrees: {
+    agreeAge: boolean;
+    agreeTerms: boolean;
+    agreePrivacy: boolean;
+    agreePromotion: boolean;
+  };
+}
+
+export default async function PostSignUp(body: IPostSignUp) {
+  const data = await api.post({
+    endpoint: '/users/signup',
+    body,
+  });
+  return data;
+}

--- a/src/api/getNicknameCheck.ts
+++ b/src/api/getNicknameCheck.ts
@@ -1,0 +1,6 @@
+import api from '@/_lib/fetcher';
+
+export default async function getNicknameCheck(nickname: string) {
+  const data = await api.get({ endpoint: `/users/nicknamecheck?nickname=${nickname}` });
+  return data;
+}

--- a/src/api/postComment.ts
+++ b/src/api/postComment.ts
@@ -9,7 +9,7 @@ interface IPostComment {
 
 export default async function PostComment(body: IPostComment, token: string) {
   const data = await api.post({
-    endpoint: `/api/post/{postid}/comment`,
+    endpoint: `/post/{postid}/comment`,
     body,
     authorization: token,
   });

--- a/src/app/home/_component/ProfileModal.tsx
+++ b/src/app/home/_component/ProfileModal.tsx
@@ -9,13 +9,22 @@ import { useRouter } from 'next/navigation';
 
 interface IProfileModalProps {
   handleLogoutClick: () => void;
+  nickname: string;
+  profileImage: string;
+  email: string;
 }
 
-export default function ProfileModal({ handleLogoutClick }: IProfileModalProps) {
+export default function ProfileModal({
+  handleLogoutClick,
+  nickname,
+  email,
+  profileImage,
+}: IProfileModalProps) {
   const router = useRouter();
 
   const handleMyPageBtnClick = (): void => {
-    router.push('/myPage');
+    return;
+    // router.push('/myPage');
   };
 
   const handleMyJudgeBtnClick = (): void => {
@@ -31,15 +40,19 @@ export default function ProfileModal({ handleLogoutClick }: IProfileModalProps) 
   return (
     <>
       <div
-        className='w-[200px] h-[205px] border border-[#8A1F21] rounded-[18px] p-[13px] bg-[#FFFFFF]'
-        style={{ position: 'absolute', transform: 'translate(-20%,65%)' }}
+        className='w-[250px] h-[205px] border border-[#8A1F21] rounded-[18px] p-[13px] bg-[#FFFFFF] z-50'
+        style={{ position: 'absolute', transform: 'translate(-35%,65%)' }}
       >
         <div className='flex flex-col gap-[8.5px]'>
           <div className='flex flex-row gap-[10px] mb-[9px]'>
-            <IoPersonCircle className='h-[2.2rem] w-[2.2rem]' />
+            <img
+              src={profileImage}
+              alt='profileImage'
+              className='h-[2.2rem] w-[2.2rem] rounded-full'
+            />
             <div className='flex-col gap-[15px]'>
-              <p className='text-[14px] font-semibold text-[#000000]'>김철수</p>
-              <p className='text-[12px] font-medium text-[#555555]'>@가나다라마바사아자차</p>
+              <p className='text-[14px] font-semibold text-[#000000]'>{nickname}</p>
+              <p className='text-[12px] font-medium text-[#555555]'>@ {email}</p>
             </div>
           </div>
 

--- a/src/app/login/naver/page.tsx
+++ b/src/app/login/naver/page.tsx
@@ -4,6 +4,7 @@ import NaverLogin from '@/api/naver/naverLogin';
 import { useMutation } from '@tanstack/react-query';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useEffect } from 'react';
+import { useAuthStore } from '../store/useAuthStore';
 
 export default function Naver() {
   const router = useRouter();
@@ -13,7 +14,26 @@ export default function Naver() {
 
   const { mutate: login } = useMutation({
     mutationFn: () => NaverLogin({ code, state }),
-    onSuccess: () => router.push('/home'),
+    mutationKey: ['login'],
+    onSuccess: (data) => {
+      if (data.resultCode === 409) {
+        localStorage.setItem('email', data.email);
+        localStorage.setItem('profileImage', data.profileImage);
+        // alert(data.resultMsg) 두번 경고창 나오는 오류
+        router.push('/signUp');
+      } else if (data.resultCode === 200) {
+        localStorage.setItem('email', data.email);
+        localStorage.setItem('profileImage', data.profileImage);
+        localStorage.setItem('nickname', data.nickname);
+        useAuthStore.setState({
+          isLogin: true,
+          accessToken: data.accessToken,
+          refreshToken: data.refreshToken,
+        });
+        // alert(data.resultMsg);
+        router.push('/home');
+      }
+    },
     onError: (error) => console.log(error),
     onSettled: (data) => console.log(data),
   });
@@ -23,7 +43,7 @@ export default function Naver() {
   }, []);
 
   return (
-    <div>
+    <div className='flex flex-grow flex-column h-[100vh] justify-center items-center'>
       <h1>네이버 로그인 중...</h1>
     </div>
   );

--- a/src/app/login/store/useAuthStore.ts
+++ b/src/app/login/store/useAuthStore.ts
@@ -5,21 +5,17 @@ import { persist } from 'zustand/middleware';
 
 type LoginState = {
   isLogin: boolean;
-  accessToken: string | null;
-  refreshToken: string | null;
-  setLoginState: (
-    isLogin: boolean,
-    accessToken: string | null,
-    refreshToken: string | null,
-  ) => void;
+  accessToken: string;
+  refreshToken: string;
+  setLoginState: (isLogin: boolean, accessToken: string, refreshToken: string) => void;
 };
 
 export const useAuthStore = create<LoginState>(
   persist(
     (set) => ({
       isLogin: false,
-      accessToken: null,
-      refreshToken: null,
+      accessToken: '',
+      refreshToken: '',
       setLoginState: (isLogin, accessToken, refreshToken) =>
         set({
           isLogin,
@@ -43,6 +39,6 @@ export const getStoredLoginState = () => {
     const refreshToken = storedData.state.refreshToken;
     return { isLogin, accessToken, refreshToken };
   } else {
-    return { isLogin: false, accessToken: null, refreshToken: null };
+    return { isLogin: false, accessToken: '', refreshToken: '' };
   }
 };

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -4,18 +4,21 @@ import Image from 'next/image';
 import { IoMdNotificationsOutline } from 'react-icons/io';
 import { IoPersonCircle } from 'react-icons/io5';
 import writeSVG from '../../public/svg/writing.svg';
-
 import { useState } from 'react';
 import ProfileModal from '@/app/home/_component/ProfileModal';
 import AlarmModal from '@/app/home/_component/AlarmModal';
 import { usePathname, useRouter } from 'next/navigation';
+import { getStoredLoginState, useAuthStore } from '@/app/login/store/useAuthStore';
 
 export default function Header() {
   const router = useRouter();
-  const [isLogin, setIsLogin] = useState<boolean>(false);
+  const { isLogin } = getStoredLoginState();
   const [isAlarmModalOpen, setIsAlarmModalOpen] = useState<boolean>(false);
   const [isProfileModalOpen, setIsProfileModalOpen] = useState<boolean>(false);
   const currentUrl = usePathname();
+  const email = String(localStorage.getItem('email'));
+  const nickname = String(localStorage.getItem('nickname'));
+  const profileImage = String(localStorage.getItem('profileImage'));
 
   const handleAlarmBtnClick = (): void => {
     if (isProfileModalOpen) {
@@ -38,7 +41,8 @@ export default function Header() {
   const handleLogoutBtnClick = (): void => {
     // 로그아웃 기능 후 페이지는 제자리
     setIsProfileModalOpen(false);
-    setIsLogin(false);
+    useAuthStore.setState({ isLogin: false, accessToken: '', refreshToken: '' });
+    localStorage.clear();
     return;
   };
 
@@ -83,7 +87,14 @@ export default function Header() {
               >
                 <IoPersonCircle className='h-[2.2rem] w-[2.2rem]' />
               </button>
-              {isProfileModalOpen && <ProfileModal handleLogoutClick={handleLogoutBtnClick} />}
+              {isProfileModalOpen && (
+                <ProfileModal
+                  handleLogoutClick={handleLogoutBtnClick}
+                  email={email}
+                  profileImage={profileImage}
+                  nickname={nickname}
+                />
+              )}
             </>
           ) : (
             <>


### PR DESCRIPTION
Feat: 회원가입 버튼 눌렀을때 api 연동 작업 완료
Feat: 회원가입 여부에 따라 네이버 로그인 성공 후 회원가입 페이지, 또는 메인페이지로 이동하도록 기능 구현
Chore: 로그인 상태, 토큰들에 대한 전역 상태변수 선언
Feat: 전역 상태변수로 저장한 로그인 상태 여부에 따라 헤더의 아이콘들 보여주는걸로 수정
Feat: 프로필 아이콘 눌렀을때 보여주는 프로필 이미지, 닉네임, 이메일 로컬 스토리지에서 저장된 값 호출해서 보여주기
![image](https://github.com/vsgg12/VSGG-FE/assets/91364411/b9256c9d-a438-4734-906d-d2f77705194d)

Feat: 회원가입 버튼 누르면 호출하는 api 함수 정의 
Feat: 닉네임 중복 체크 api 연동하는 함수 정의

=> 로그인 성공 후 로컬스토리지에 저장되는 값들
1. isLogin, accessToken, refreshToken(zustand로 관리)
2. nickname
3. profileImage
4. email