### PR TITLE
fix: 리프레시 토큰으로 토큰 재발급하는 api 호출하는 로직 관련 수정작업

### DIFF
--- a/src/_lib/fetcher.ts
+++ b/src/_lib/fetcher.ts
@@ -1,3 +1,4 @@
+'use client';
 import postRefresh from '@/api/postRefresh';
 import RefreshTokenExpired from './refreshTokenExpired';
 import { useAuthStore } from '@/app/login/store/useAuthStore';
@@ -59,14 +60,14 @@ const _fetch = async <T = unknown, R = unknown>({
         const { refreshToken } = useAuthStore.getState();
         if (refreshToken) {
           try {
-            const newToken = await postRefresh({ refreshToken: `Bearer ${refreshToken}` });
-            if (newToken) {
+            const newToken: IPostRefreshType = await postRefresh(refreshToken);
+            if (newToken.resultCode === 200) {
               useAuthStore.setState({
                 isLogin: true,
-                accessToken: newToken.tokens?.accessToken,
-                refreshToken: refreshToken,
+                accessToken: newToken.tokens.accessToken,
+                refreshToken: newToken.tokens.refreshToken,
               });
-              headers.Authorization = 'Bearer ' + newToken.tokens?.accessToken;
+              headers.Authorization = 'Bearer ' + newToken.tokens.accessToken;
               const retryRequestOptions: RequestInit = {
                 ...requestOptions,
                 headers,
@@ -86,6 +87,9 @@ const _fetch = async <T = unknown, R = unknown>({
             RefreshTokenExpired();
             throw new Error('Session expired. Please log in again.');
           }
+        } else {
+          RefreshTokenExpired();
+          throw new Error('Session expired. Please log in again.');
         }
       }
       const errorData = await res.json();

--- a/src/_lib/refreshTokenExpired.ts
+++ b/src/_lib/refreshTokenExpired.ts
@@ -1,12 +1,18 @@
 'use client';
 import { useAuthStore } from '@/app/login/store/useAuthStore';
 import { useRouter } from 'next/navigation';
+import { useEffect } from 'react';
 
 const RefreshTokenExpired = () => {
   const router = useRouter();
-  useAuthStore.setState({ isLogin: false, accessToken: '', refreshToken: '' });
-  localStorage.clear();
-  router.push('/login');
+
+  useEffect(() => {
+    useAuthStore.setState({ isLogin: false, accessToken: '', refreshToken: '' });
+    localStorage.clear();
+    router.replace('/login');
+  }, [router]);
+
+  return null;
 };
 
 export default RefreshTokenExpired;

--- a/src/api/postRefresh.ts
+++ b/src/api/postRefresh.ts
@@ -1,22 +1,8 @@
 import api from '@/_lib/fetcher';
 
-interface IRefreshToken {
-  refreshToken: string;
-}
-
-interface IResponse {
-  resultCode: number;
-  resultMsg: string;
-  tokens?: {
-    accessToken: string;
-    refreshToken: string;
-  };
-}
-
-export default async function postRefresh(body: IRefreshToken) {
-  const data = await api.post<IRefreshToken, IResponse>({
+export default async function postRefresh(refreshToken: string): Promise<IPostRefreshType> {
+  return await api.post<{ refreshToken: string }, IPostRefreshType>({
     endpoint: '/users/token/refresh',
-    body,
+    body: { refreshToken: `Bearer ${refreshToken}` },
   });
-  return data;
 }


### PR DESCRIPTION
1. src/_api/fetcher.ts 파일에서 try-catch문 로직 수정 및 서버 컴포넌트에서는 클라이언트 컴포넌트인 useAuthStore(), RefreshTokenExpired()가 제대로 동작하지 않을 수도 있기 떄문에 클라이언트 컴포넌트로 수정 선언

2. src/_api/refreshTokenExpired.ts 파일에서 useEffect()를 사용해 컴포넌트가 마운트된 후에만 해당 작업이 수행되도록 수정함

3. src/api/postRefresh.ts 파일에서는 request body에 데이터 넘겨주는 방식을 기존에 fetcher에서 객체자체를 넘겨줬던 방식에서 fetcher에서는 refreshToken: string만 넘겨주고 postRefresh 함수에서 Bearer를 추가해 객체형식으로 body에 넣어 보내는 방식으로 코드 수정