### PR TITLE
Style: 투표 마감기한 컴포넌트 추가

### DIFF
--- a/src/app/home/_component/HomePostItems.tsx
+++ b/src/app/home/_component/HomePostItems.tsx
@@ -8,6 +8,8 @@ import { useEffect, useState } from 'react';
 import moment from 'moment';
 import useConvertHTML from '@/hooks/useConvertHTML';
 import { useAuthStore } from '@/app/login/store/useAuthStore';
+import PostDeadLine from '@/components/PostDeadLine';
+import { formatNumberWithCommas } from '@/utils/formatNumberWithCommas';
 
 export default function HomePostItems({
   post,
@@ -53,25 +55,30 @@ export default function HomePostItems({
       <div>
         {post && (
           <div
-            className='px-[55px] pt-[40px] pb-[30px] h-fit min-w-[1205px] mb-[50px] rounded-[1.875rem] bg-[#ffffff] cursor-pointer'
+            className='px-[55px] pt-[40px] pb-[30px] h-fit min-w-[1205px] mb-[50px] rounded-[1.875rem] bg-[#ffffff] cursor-pointer flex flex-col gap-[10px]'
             onClick={() => {
               router.push(`/post/${post.id}/`);
             }}
           >
-            <div className='flex w-full flex-row justify-between font-medium'>
-              <div className='p-content-s-mb text-[1.563rem]'>{post.title}</div>
-              <div className='text-[0.75rem] text-[#C8C8C8]'>조회수 {post.viewCount}</div>
+            <div className='flex w-full font-medium justify-center items-center gap-[8px]'>
+              <div className='text-black text-[1.563rem]'>{post.title}</div>
+              <div className='text-[#C8C8C8] flex-grow text-[0.75rem]'>
+                | 조회수 {formatNumberWithCommas(post.viewCount)}
+              </div>
+              <PostDeadLine deadLine={post.daysUntilEnd} />
             </div>
-            <div className='p-content-s-mb flex flex-row items-center justify-start font-medium'>
-              <IoPersonCircleSharp className='mr-[0.625rem] h-[2.5rem] w-[2.5rem] rounded-full  text-[#D9D9D9]' />
-              <div>
-                <div className='flex flex-row'>
-                  <div className='mr-[0.625rem] text-[0.75rem] text-[#333333]'>
-                    {post.memberDTO.nickname}
+            <div className='justify-start font-medium'>
+              <div className='flex'>
+                <IoPersonCircleSharp className='mr-[0.625rem] h-[2.5rem] w-[2.5rem] rounded-full  text-[#D9D9D9]' />
+                <div className='flex flex-col'>
+                  <div className='flex'>
+                    <div className='mr-[0.625rem] text-[0.75rem] text-[#333333]'>
+                      {post.memberDTO.nickname}
+                    </div>
+                    <div className='text-[0.75rem] text-[#909090]'>{post.memberDTO.tier}</div>
                   </div>
-                  <div className='text-[0.75rem] text-[#909090]'>{post.memberDTO.tier}</div>
+                  <div className='text-[0.75rem] text-[#C8C8C8]'>{formattedDate}</div>
                 </div>
-                <div className='text-[0.75rem] text-[#C8C8C8]'>{formattedDate}</div>
               </div>
             </div>
             <div className='flex h-fit flex-row'>
@@ -118,7 +125,9 @@ export default function HomePostItems({
                   })}
                 </div>
                 <div className='relative flex h-[167px] items-center justify-center rounded-[1.875rem] bg-gradient-to-b from-[#ADADAD]/30 to-[#DCDCDC]/30'>
-                  {post.isVote || post.memberDTO.nickname === user?.nickname ? (
+                  {post.isVote ||
+                  post.memberDTO.nickname === user?.nickname ||
+                  post.status === 'FINISHED' ? (
                     <HomeVoted voteInfos={voteInfos} />
                   ) : (
                     <HomeNotVoted voteInfos={voteInfos} />

--- a/src/app/home/_component/ListedPostItem.tsx
+++ b/src/app/home/_component/ListedPostItem.tsx
@@ -1,5 +1,5 @@
-// import Image from 'next/image';
-// import Icon_timer from '../../../../public/svg/timer.svg';
+import PostDeadLine from '@/components/PostDeadLine';
+import { formatNumberWithCommas } from '@/utils/formatNumberWithCommas';
 import moment from 'moment';
 import { useRouter } from 'next/navigation';
 
@@ -9,9 +9,10 @@ interface IListedItem {
 
 export default function ListedPostItem({ post }: IListedItem) {
   const router = useRouter();
+  console.log("exist", post)
   return (
     <div
-      className='flex flex-col w-[1205px] h-[135px] bg-white mb-[20px] rounded-[30px] p-[30px] gap-[10px] cursor-pointer'
+      className='flex flex-col min-w-[1205px] h-[135px] bg-white mb-[20px] rounded-[30px] p-[30px] gap-[10px] cursor-pointer'
       onClick={() => {
         router.push(`/post/${post.id}/`);
       }}
@@ -24,12 +25,11 @@ export default function ListedPostItem({ post }: IListedItem) {
         <p className='text-[#C8C8C8] text-[12px]'>{moment(post.createdAt).format('YYYY-MM-DD')}</p>
       </div>
       <div className='flex justify-center items-center gap-[5px]'>
-        <p className='text-black text-[25px]'>{post.title}</p>
-        <p className='text-[#C8C8C8] flex-grow'>| 조회수 {post.viewCount}</p>
-        {/* <div className='flex items-center justify-center gap-[5px] text-[18px] text-white w-[182px] h-[28px] rounded-[20px] bg-[#8A1F21]'>
-          <Image src={Icon_timer} width={20} height={20} alt='timer' />
-          투표 마감까지 일
-        </div> */}
+        <div className='text-black text-[25px]'>{post.title}</div>
+        <div className='text-[#C8C8C8] flex-grow'>
+          | 조회수 {formatNumberWithCommas(post.viewCount)}
+        </div>
+        <PostDeadLine deadLine={post.daysUntilEnd} />
       </div>
     </div>
   );

--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -76,9 +76,7 @@ export default function Home() {
     if (postData && postData.postDTO && postData.postDTO.length > 0) {
       const filteredData = postData.postDTO.filter((post) => post.isDeleted === 'FALSE');
       setExistData(filteredData);
-    } else {
-      console.log('No valid postData or postDTO');
-    }
+    } 
   }, [postData]);
 
   const handleSearch = () => {
@@ -89,15 +87,15 @@ export default function Home() {
     }
   };
 
-  const getPostData = useCallback(() => postData, [postData]);
+  const getPostData = useCallback(() => existData, [existData]);
   const getPostIndex = useCallback(() => postIndex, [postIndex]);
 
   const loadMore = useCallback(() => {
-    const postLength = postData ? postData.postDTO.length : 0;
+    const postLength = existData ?existData.length : 0;
     const currentPostData = getPostData();
     const currentPostIndex = getPostIndex();
     if (currentPostData) {
-      const newPosts = currentPostData.postDTO.slice(
+      const newPosts = currentPostData.slice(
         currentPostIndex,
         currentPostIndex + 5 < postLength ? currentPostIndex + 5 : postLength,
       );
@@ -113,7 +111,7 @@ export default function Home() {
           if (entry.isIntersecting) {
             const currentPostIndex = getPostIndex();
             const currentPostData = getPostData();
-            if (currentPostData && currentPostIndex < currentPostData.postDTO.length) {
+            if (currentPostData && currentPostIndex < currentPostData.length) {
               loadMore();
             }
           }

--- a/src/app/myPage/page.tsx
+++ b/src/app/myPage/page.tsx
@@ -17,6 +17,7 @@ import Image from 'next/image';
 import editProgileIcon from '../../../public/svg/editProfileIcon.svg';
 import getMyJudgeList from '@/api/getMyJudgeList';
 import MyJudgeList from './_component/MyJudgeList';
+import { formatNumberWithCommas } from '@/utils/formatNumberWithCommas';
 
 export default function MyPage() {
   const router = useRouter();
@@ -75,7 +76,7 @@ export default function MyPage() {
               </div>
               <div className='text-[20px]'>{userProfileData.memberProfileDTO.tier}</div>
               <div className='text-[16px] mb-[5px]'>
-                보유 포인트 : {userProfileData.memberProfileDTO.point}P
+                보유 포인트 : {formatNumberWithCommas(userProfileData.memberProfileDTO.point)}P
               </div>
               <div className='h-1 w-full bg-[#8A1F21]' />
               <div className='h-[350px] flex flex-col items-center relative'>

--- a/src/app/post/[postId]/page.tsx
+++ b/src/app/post/[postId]/page.tsx
@@ -28,6 +28,8 @@ import { useForm, FormProvider } from 'react-hook-form';
 import Image from 'next/image';
 import Icon_more from '../../../../public/svg/Icon_more.svg';
 import MoreModal from '@/components/modals/MoreModal';
+import PostDeadLine from '@/components/PostDeadLine';
+import { formatNumberWithCommas } from '@/utils/formatNumberWithCommas';
 
 export default function PostRead() {
   const { postId } = useParams();
@@ -205,7 +207,8 @@ export default function PostRead() {
                 {post && (
                   <div className='p-content-mr p-content-rounded scroll relative mb-11 max-h-[1000px] w-2/3 min-w-[600px] bg-white px-[63px] pb-[44px]'>
                     <div className='sticky top-[-1px] bg-[#ffffff] pb-[30px] pt-[44px] z-10'>
-                      <div className='flex justify-end relative'>
+                      <div className='flex justify-between relative mb-[10px]'>
+                        <PostDeadLine deadLine={post.postDTO.daysUntilEnd} />
                         <Image
                           className='cursor-pointer'
                           alt='moreIcon'
@@ -241,7 +244,7 @@ export default function PostRead() {
                           <div className='text-[12px] text-[#C8C8C8]'>{formattedDate}</div>
                         </div>
                         <p className='text-[12px] text-[#C8C8C8] mt-[20px]'>
-                          조회수 {post.postDTO.viewCount}
+                          조회수 {formatNumberWithCommas(post.postDTO.viewCount)}
                         </p>
                       </div>
                     </div>
@@ -376,8 +379,8 @@ export default function PostRead() {
                   </div>
                 </div>
               </div>
-              {(voteData && isOwner) || post?.postDTO.isVote ? (
-                <VoteResult voteInfos={voteData} isOwner={isOwner} />
+              {(voteData && isOwner) || post?.postDTO.isVote || post?.postDTO.status === "FINISHED" ? (
+                  <VoteResult voteInfos={voteData} isOwner={isOwner} isFinished={post?.postDTO.status === "FINISHED"} />
               ) : (
                 post &&
                 !isOwner && <VoteForm voteInfo={voteData} handleVoteSubmit={handleVoteSubmit} />

--- a/src/app/post/_component/VoteResult.tsx
+++ b/src/app/post/_component/VoteResult.tsx
@@ -10,9 +10,10 @@ import { useEffect, useState } from 'react';
 interface IVoteResultProps {
   voteInfos: IGetInGameInfoType[] | undefined;
   isOwner: boolean;
+  isFinished: boolean;
 }
 
-export default function VoteResult({ voteInfos, isOwner }: IVoteResultProps) {
+export default function VoteResult({ voteInfos, isOwner, isFinished }: IVoteResultProps) {
   const [isNoOneVoted, setIsNoOneVoted] = useState<boolean>(false);
 
   useEffect(() => {
@@ -90,7 +91,7 @@ export default function VoteResult({ voteInfos, isOwner }: IVoteResultProps) {
                 {isOwner && isNoOneVoted ? (
                   <div className='flex relative w-[340px] justify-center'>
                     <p className='flex justify-center items-center absolute text-[20px] inset-0 text-[#828282]'>
-                      아직 투표한 사람이 없는 게시글입니다.
+                      {isFinished ? "투표한 사람이 없는 게시글입니다.":"아직 투표한 사람이 없는 게시글입니다."}
                     </p>
                     <Image className='mr-7' src={Doughnut} width={175} height={175} alt='noVote' />
                   </div>
@@ -100,7 +101,7 @@ export default function VoteResult({ voteInfos, isOwner }: IVoteResultProps) {
               </div>
 
               <div className='flex flex-col justify-end mr-10'>
-                {!isOwner && (
+                {isFinished ? null : !isOwner && (
                   <button className='h-9 w-28 rounded-full bg-[#ECECEC] text-lg text-[#828282]'>
                     제출완료
                   </button>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -148,7 +148,11 @@ export default function Header() {
                 <ProfileModal
                   handleLogoutClick={handleLogoutBtnClick}
                   email={user.email}
-                  profileImage={userProfileData?.memberProfileDTO.profileUrl}
+                  profileImage={
+                    userProfileData?.memberProfileDTO.profileUrl === 'none'
+                      ? 'https://ssl.pstatic.net/static/pwe/address/img_profile.png'
+                      : userProfileData?.memberProfileDTO.profileUrl
+                  }
                   nickname={user.nickname}
                 />
               )}

--- a/src/components/PostDeadLine.tsx
+++ b/src/components/PostDeadLine.tsx
@@ -1,0 +1,28 @@
+import Image from 'next/image';
+import React, { useEffect, useState } from 'react';
+import timerIcon from '../../public/svg/timer.svg';
+
+function PostDeadLine({deadLine}:{deadLine: number}) {
+    const [message, setMessage] = useState<string>("")
+
+    useEffect(() => {
+        if (deadLine === 0) {
+            setMessage("오늘 투표 마감!")
+        }
+        else if (deadLine < 0) {
+            setMessage("투표 마감")
+        }
+        else {
+            setMessage(`투표 마감까지 ${deadLine}일`)
+        }
+    }, [deadLine])
+
+  return (
+    <div className='flex items-center justify-center gap-[4px] max-w-[190px] px-[10px] py-[4px] h-[28px] rounded-[20px] bg-[#8A1F21]'>
+      <Image src={timerIcon} width={20} height={20} alt='timer' />
+      <span className='text-white text-[18px]'>{message}</span>
+    </div>
+  );
+}
+
+export default PostDeadLine;

--- a/src/types/get.d.ts
+++ b/src/types/get.d.ts
@@ -11,7 +11,7 @@ type IGetPostDTOType = {
   content: string;
   thumbnailURL: string;
   viewCount: number;
-  status: string;
+  status: string | "PROGRESS" | "FINISHED";
   video: IGetVideoType;
   memberDTO: IGetMemberDTOType;
   createdAt: string;
@@ -20,6 +20,7 @@ type IGetPostDTOType = {
   inGameInfoList: IGetInGameInfoType[];
   isVote: boolean;
   isDeleted: 'TRUE' | 'FALSE';
+  daysUntilEnd: number;
 };
 
 type IGetVideoType = {

--- a/src/utils/formatNumberWithCommas.ts
+++ b/src/utils/formatNumberWithCommas.ts
@@ -1,0 +1,4 @@
+export const formatNumberWithCommas = (number: number):string => {
+    return number.toLocaleString('en-US');
+}
+


### PR DESCRIPTION

추가된 부분
* 게시글 삭제 정상적으로 작동
* 게시글 목록, 게시글 상세 페이지 투표 마감 일자 컴포넌트 퍼블리싱
* 마이페이지 보유포인트, 조회수에 ,(쉼표) 걸어주기

프론트엔드 리팩토링
* 게시글 삭제한 후 메인페이지에서 data받아올때 삭제된 게시글도 같이 받아와져서 생기는 에러 해결(isDeleted === “FALSE”인 게시글만 보여주도록 수정)
* 마이페이지 프로필 이미지 기본 이미지로 변경 후에 헤더 및 마이페이지에서 기본이미지로 안보이는 오류 수정
* 게시글 상세 페이지, 목록 페이지에서 투표 마감된 게시글인 경우 자기가 투표 안한 게시글이면 투표 결과가 아닌 투표 화면이 보이던 오류 수정


+ 추가로 확인이 필요한 QA 오류
1. 운영서버 마이페이지 프로필 이미지 변경 안되는 에러 발생  ->같은 환경에서 개발서버, 운영서버 같은 이미지 같은 과정으로 이미지 변경 시도  ->  개발서버에서는 문제 없이 잘 동작하지만 운영서버에서는 이미지 변경 시 80%확률로 patch하는데 413에러가 발생  -> 백엔드에서도 확인 필요
2. 운영서버 메인페이지 처음 접속했을 때 게시글 목록이 안뜨고 게시글이 없다는 문구가 나온다는 에러 -> 프론트에서는 이전에 데이터를 받아오기전까지 로딩 스피너가 표시되도록 로직을 걸어뒀었는데도 해당 에러 발생함