### PR TITLE
fix: 사소한 디자인 수정과 투표 컴포넌트 챔피온 로딩 

### DIFF
--- a/src/app/home/_component/vote/champion/ChampionVoteBox.tsx
+++ b/src/app/home/_component/vote/champion/ChampionVoteBox.tsx
@@ -112,8 +112,6 @@ const ChampionVoteBox = ({
               </div>
             )
           )}
-
-          {/* 로그인 상태지만 투표 없음 */}
         </div>
       )}
     </div>

--- a/src/app/home/_component/vote/champion/ChampionVoteResultItem.tsx
+++ b/src/app/home/_component/vote/champion/ChampionVoteResultItem.tsx
@@ -61,7 +61,6 @@ const ChampionVoteResultItem = ({ voteItem, isHover, isHome = false }: Props) =>
           </div>
         </div>
       </div>
-
       {/* 육각형 */}
       <div
         className={clsx(

--- a/src/app/home/_component/vote/claim/ClaimVoteItem.tsx
+++ b/src/app/home/_component/vote/claim/ClaimVoteItem.tsx
@@ -74,7 +74,6 @@ const ClaimVoteItem = ({ voteItem, shouldBlur, onVoteItemClick }: Props) => {
         {!shouldBlur && (
           <div className='flex flex-col items-end justify-center shrink-0 font-semibold gap-1.5'>
             <span className='text-[24px] leading-none'>{voteItem.averageRatio}%</span>
-            <span className='text-[12px]'>{voteItem.voteCount}표</span>
           </div>
         )}
       </div>

--- a/src/app/home/mobile/component/ChampionVoteBoxMobile.tsx
+++ b/src/app/home/mobile/component/ChampionVoteBoxMobile.tsx
@@ -79,7 +79,6 @@ const ChampionVoteBoxMobile = ({
               <div className='text-[40px] font-bold'>
                 {(currentHoverItem.averageRatio ?? 0).toFixed(1)}
               </div>
-              <div className='text-[20px] font-semibold'>{currentHoverItem.voteCount}표</div>
             </div>
           )}
         </div>

--- a/src/app/post/[postId]/desktop/components/Comment/CommentItem.tsx
+++ b/src/app/post/[postId]/desktop/components/Comment/CommentItem.tsx
@@ -24,7 +24,6 @@ export default function CommentItem({ comment, targetComment, handleReply }: ICo
             {truncateText(comment.member.nickname, 8)}
           </p>
         </div>
-        <p className='text-[14px] text-[#909090] min-w-fit'>{comment.member.tier}</p>
         <p className='text-[12px] text-[#C8C8C8] ml-2 min-w-fit'>| {timeAgo}</p>
       </div>
       <p className='text-[14px] mb-[7px]'>

--- a/src/app/post/[postId]/desktop/components/vote/ChampionImgBox.tsx
+++ b/src/app/post/[postId]/desktop/components/vote/ChampionImgBox.tsx
@@ -2,6 +2,7 @@ import Image from 'next/image';
 import React from 'react';
 import { useChampion } from '@/hooks/useChampion';
 import IconVote from '../../../../../../../public/svg/postItem/vote.svg';
+import Loading from '@/components/Loading';
 
 interface IProps {
   selectedChampion: string;
@@ -16,7 +17,7 @@ export default function ChampionImgBox({
   isHamburgerClicked,
   voteInfo,
 }: IProps) {
-  const { getImageUrlByName } = useChampion();
+  const { getImageUrlByName, loading } = useChampion();
 
   return (
     <div className='flex flex-col gap-[13px]'>
@@ -26,29 +27,37 @@ export default function ChampionImgBox({
       </div>
       {isHamburgerClicked ? (
         <div className='flex relative w-[659px] h-[201px] rounded-[20px] overflow-hidden'>
-          {voteInfo.map((champion) => (
-            <div
-              style={{ width: `${659 / voteInfo.length}px`, height: '201px' }}
-              className='relative'
-              key={champion.championName}
-            >
-              <Image
-                src={getImageUrlByName(champion.championName)}
-                alt='champion'
-                fill
-                className='object-cover'
-              />
-            </div>
-          ))}
+          {loading ? (
+            <Loading />
+          ) : (
+            voteInfo.map((champion) => (
+              <div
+                style={{ width: `${659 / voteInfo.length}px`, height: '201px' }}
+                className='relative'
+                key={champion.championName}
+              >
+                <Image
+                  src={getImageUrlByName(champion.championName)}
+                  alt='champion'
+                  fill
+                  className='object-cover'
+                />
+              </div>
+            ))
+          )}
         </div>
       ) : (
         <div className='relative w-[659px] h-[201px] rounded-[20px] overflow-hidden'>
-          <Image
-            src={getImageUrlByName(selectedChampion, 'flash')}
-            alt='champion'
-            fill
-            className='object-cover object-top'
-          ></Image>
+          {loading ? (
+            <Loading />
+          ) : (
+            <Image
+              src={getImageUrlByName(selectedChampion, 'flash')}
+              alt='champion'
+              fill
+              className='object-cover object-top'
+            ></Image>
+          )}
         </div>
       )}
     </div>

--- a/src/components/Loading.tsx
+++ b/src/components/Loading.tsx
@@ -1,8 +1,8 @@
 export default function Loading() {
   return (
     <>
-      <div className=" flex w-full items-center justify-center ">
-        <div className="loader"></div>
+      <div className=' flex h-fit w-full items-center justify-center '>
+        <div className='loader'></div>
       </div>
     </>
   );


### PR DESCRIPTION
- 게시글 상세 페이지 댓글 부분에 티어 이름 빼기
- 투표 컴포넌트에서 챔피온 이미지 가져올 때 로딩 걸기 